### PR TITLE
Hide compile warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "code_generator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rand 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     // Once enough codes have been generated, the `code_exists_handler`
     // sends a message on the exit channel. The main thread will block
     // until it receives this.
-    exit_rx.recv();
+    let _ = exit_rx.recv();
     return;
 }
 
@@ -118,11 +118,11 @@ fn code_exists_handler(total_codes: usize, rx: Receiver<String>, printer_tx: Sen
 
         if !existing_codes.contains(&code) {
             existing_codes.insert(code.clone());
-            printer_tx.send(code);
+            let _ = printer_tx.send(code);
         }
 
         if existing_codes.len() >= total_codes {
-            printer_tx.send("last-code".to_string());
+            let _ = printer_tx.send("last-code".to_string());
             break;
         }
     }
@@ -141,7 +141,7 @@ fn print_handler(rx: Receiver<String>, exit_tx: Sender<bool>) {
         match rx.recv() {
             Ok(code) => {
                 if &code == "last-code" {
-                    exit_tx.send(true);
+                    let _ = exit_tx.send(true);
                 } else {
                     println!("{}", code);
                 }


### PR DESCRIPTION
silence numerous warnings based on:
`warning: unused result which must be used`

Not sure if using `_` is the right answer but cleaned up my build.
